### PR TITLE
Port to the Minitel 1B too

### DIFF
--- a/minitel2/the_minitel_demo/compile.bat
+++ b/minitel2/the_minitel_demo/compile.bat
@@ -1,9 +1,23 @@
 @call clean
-@sdcc -c demo_minitel.c --xram-loc 0x0000 --xram-size 0x10000 --opt-code-speed
-@sdcc -c troisd_func.c --xram-loc 0x0000 --xram-size 0x10000 --opt-code-speed
-@sdcc -c deuxd_func.c --xram-loc 0x0000 --xram-size 0x10000 --opt-code-speed
-@sdcc -c minitel_hw.c --xram-loc 0x0000 --xram-size 0x10000 --opt-code-speed
-@sdcc demo_minitel.rel troisd_func.rel deuxd_func.rel minitel_hw.rel --xram-loc 0x0000 --xram-size 0x10000 --opt-code-speed
+
+@echo Select the target Minitel model:
+@echo 1. NFZ 330 (RTIC Minitel 1B)
+@echo 2. NFZ 400 (Philips Minitel 2)
+@set SEL=
+@set MODEL=
+@set /P SEL=Target model (1 or 2)?
+@IF "%SEL%" == "1" set MODEL=NFZ330
+@IF "%SEL%" == "2" set MODEL=NFZ400
+@IF NOT "%MODEL%" == "" goto compile
+@echo Invalid selection
+goto errorend
+
+:compile
+@sdcc -c demo_minitel.c --xram-loc 0x0000 --xram-size 0x10000 --opt-code-speed -DMINITEL_%MODEL%
+@sdcc -c troisd_func.c --xram-loc 0x0000 --xram-size 0x10000 --opt-code-speed -DMINITEL_%MODEL%
+@sdcc -c deuxd_func.c --xram-loc 0x0000 --xram-size 0x10000 --opt-code-speed -DMINITEL_%MODEL%
+@sdcc -c minitel_hw.c --xram-loc 0x0000 --xram-size 0x10000 --opt-code-speed -DMINITEL_%MODEL%
+@sdcc demo_minitel.rel troisd_func.rel deuxd_func.rel minitel_hw.rel --xram-loc 0x0000 --xram-size 0x10000 --opt-code-speed -DMINITEL_%MODEL%
 rem hex2bin demo_minitel.ihx
 rem copy demo_minitel.bin  F:\msys64\home\User\mame\roms\minitel2\demo_minitel.bin
 @IF NOT "%ERRORLEVEL%" == "0" goto errorend

--- a/minitel2/the_minitel_demo/demo_minitel.h
+++ b/minitel2/the_minitel_demo/demo_minitel.h
@@ -21,7 +21,9 @@
 ///////////////////////////////////////////////////////////////////////////////////
 
 void set_ptr(uint8_t X,uint8_t Y,uint8_t D,uint8_t B);
+
+#if defined(MINITEL_NFZ400)
 void write_to_modem(uint8_t datavalue,uint8_t address);
 void write_to_modem_dtmf(uint8_t datavalue,uint8_t address);
 void init_modem(void);
-
+#endif

--- a/minitel2/the_minitel_demo/deuxd_func.c
+++ b/minitel2/the_minitel_demo/deuxd_func.c
@@ -82,20 +82,20 @@ void setpixel(uint8_t x,uint8_t y, uint8_t state)
 
 		if(c>3) c=32+(c-4);
 
-		WAIT_TS9347;
+		WAIT_VIDEO_BUSY;
 
-		TS9347_R6= (0x20)|(c>>2);
-		TS9347_R7= buffernb | (k<<2)|(c&0x3);
-		TS9347_ER0=CMD_TBM| 0x08;
+		VIDEO_R6= (0x20)|(c>>2);
+		VIDEO_R7= buffernb | (k<<2)|(c&0x3);
+		VIDEO_ER0=CMD_TBM| 0x08;
 
-		WAIT_TS9347;
+		WAIT_VIDEO_BUSY;
 
 		if(state)
-			TS9347_R1=  d | TS9347_R1;
+			VIDEO_R1=  d | VIDEO_R1;
 		else
-			TS9347_R1= (~d) & TS9347_R1;
+			VIDEO_R1= (~d) & VIDEO_R1;
 
-		TS9347_ER0=CMD_TBM;
+		VIDEO_ER0=CMD_TBM;
 	}
 }
 
@@ -111,16 +111,16 @@ void setpixelFast(uint8_t x,uint8_t y)
 
 	if(c&0xFC) c=c+28;
 
-	WAIT_TS9347;
+	WAIT_VIDEO_BUSY;
 
-	TS9347_R6= (0x20)|(c>>2);
-	TS9347_R7= buffernb | (k<<2)|(c&0x3);
-	TS9347_ER0=CMD_TBM| 0x08;
+	VIDEO_R6= (0x20)|(c>>2);
+	VIDEO_R7= buffernb | (k<<2)|(c&0x3);
+	VIDEO_ER0=CMD_TBM| 0x08;
 
-	WAIT_TS9347;
-	TS9347_R1=  (0x01<<(x&0x7)) | TS9347_R1;
+	WAIT_VIDEO_BUSY;
+	VIDEO_R1=  (0x01<<(x&0x7)) | VIDEO_R1;
 
-	TS9347_ER0=CMD_TBM;
+	VIDEO_ER0=CMD_TBM;
 }
 
 

--- a/minitel2/the_minitel_demo/minitel_hw.h
+++ b/minitel2/the_minitel_demo/minitel_hw.h
@@ -22,15 +22,25 @@
 
 void clearscreen(void);
 void setbank(int8_t bank);
-void init_ts9347(void);
+void init_video(void);
 void set_ptr(uint8_t X,uint8_t Y,uint8_t D,uint8_t B);
 void fillmosaic(uint8_t x,uint8_t y,uint8_t xsize,uint8_t ysize,uint8_t page) __reentrant;
 void setcharset(int8_t * databuffer,uint8_t xsize,uint8_t ysize) __reentrant;
 void setcharset1010(const int8_t * databuffer) __reentrant;
 
 void clearcharset(uint8_t ligne) __reentrant;
+
+#if defined(MINITEL_NFZ330)
+#define XTAL_HZ 11059200
+
+#elif defined(MINITEL_NFZ400)
+#define XTAL_HZ 14318181
+
 void write_to_modem(uint8_t datavalue,uint8_t address);
 void write_to_modem_dtmf(uint8_t datavalue,uint8_t address);
 void init_modem(void);
+#endif
 
-#define WAIT_TS9347 while(TS9347_R0&0x80);
+#define TIMER16_RELOAD_VALUE(us) (uint16_t)(0x10000 - (float)(us) * XTAL_HZ / 1000000 / 12)
+
+#define WAIT_VIDEO_BUSY while(VIDEO_R0&0x80);

--- a/minitel2/the_minitel_demo/minitel_reg.h
+++ b/minitel2/the_minitel_demo/minitel_reg.h
@@ -20,6 +20,29 @@
 // Change History (most recent first):
 ///////////////////////////////////////////////////////////////////////////////////
 
+#if defined(MINITEL_NFZ330)
+////////////////////////////////////////////////////////////////////
+// Minitel 1B Hardware definition.
+////////////////////////////////////////////////////////////////////
+
+volatile __xdata __at 0xDF20 uint8_t VIDEO_R0;
+volatile __xdata __at 0xDF21 uint8_t VIDEO_R1;
+volatile __xdata __at 0xDF22 uint8_t VIDEO_R2;
+volatile __xdata __at 0xDF23 uint8_t VIDEO_R3;
+volatile __xdata __at 0xDF24 uint8_t VIDEO_R4;
+volatile __xdata __at 0xDF25 uint8_t VIDEO_R5;
+volatile __xdata __at 0xDF26 uint8_t VIDEO_R6;
+volatile __xdata __at 0xDF27 uint8_t VIDEO_R7;
+volatile __xdata __at 0xDF28 uint8_t VIDEO_ER0;
+volatile __xdata __at 0xDF29 uint8_t VIDEO_ER1;
+volatile __xdata __at 0xDF2A uint8_t VIDEO_ER2;
+volatile __xdata __at 0xDF2B uint8_t VIDEO_ER3;
+volatile __xdata __at 0xDF2C uint8_t VIDEO_ER4;
+volatile __xdata __at 0xDF2D uint8_t VIDEO_ER5;
+volatile __xdata __at 0xDF2E uint8_t VIDEO_ER6;
+volatile __xdata __at 0xDF2F uint8_t VIDEO_ER7;
+
+#elif defined(MINITEL_NFZ400)
 ////////////////////////////////////////////////////////////////////
 // Minitel 2 Hardware definition.
 // (c) 2010 Jean-François DEL NERO / HxC2001
@@ -31,6 +54,49 @@
 #define HW_CTRL_CTRON 0x08
 #define HW_CTRL_COILON 0x20
 volatile __xdata __at 0x2000 uint8_t hw_ctrl_reg;
+
+volatile __xdata __at 0x4020 uint8_t VIDEO_R0;
+volatile __xdata __at 0x4021 uint8_t VIDEO_R1;
+volatile __xdata __at 0x4022 uint8_t VIDEO_R2;
+volatile __xdata __at 0x4023 uint8_t VIDEO_R3;
+volatile __xdata __at 0x4024 uint8_t VIDEO_R4;
+volatile __xdata __at 0x4025 uint8_t VIDEO_R5;
+volatile __xdata __at 0x4026 uint8_t VIDEO_R6;
+volatile __xdata __at 0x4027 uint8_t VIDEO_R7;
+volatile __xdata __at 0x4028 uint8_t VIDEO_ER0;
+volatile __xdata __at 0x4029 uint8_t VIDEO_ER1;
+volatile __xdata __at 0x402A uint8_t VIDEO_ER2;
+volatile __xdata __at 0x402B uint8_t VIDEO_ER3;
+volatile __xdata __at 0x402C uint8_t VIDEO_ER4;
+volatile __xdata __at 0x402D uint8_t VIDEO_ER5;
+volatile __xdata __at 0x402E uint8_t VIDEO_ER6;
+volatile __xdata __at 0x402F uint8_t VIDEO_ER7;
+
+///////////////////////////////////////////////////////////
+// Modem
+///////////////////////////////////////////////////////////
+
+#define RXD_MODEM P3_3   // Modem -> CPU
+#define RTS_MODEM P1_4   // CPU -> Modem
+#define TXD_MODEM P1_3   // CPU -> Modem
+#define PRD_MODEM P1_2   // CPU -> Modem
+#define DCD_MODEM P1_1   // Modem -> CPU
+#define ZCO_MODEM P3_2   // Modem -> CPU
+
+// Note ENP set to high -> the register input is connected to PRD.
+
+#define RPROG 0x0
+#define RDTMF 0x1
+#define RATTE 0x2
+#define RWLO  0x3
+#define RPTF  0x4
+#define RHDL  0x5
+#define RPRX  0x6
+#define RPROGB  0x7
+
+#else
+#error Please define one of the MINITEL_* macros
+#endif
 
 ///////////////////////////////////////////////////////////
 // Video chip regs
@@ -62,42 +128,3 @@ volatile __xdata __at 0x2000 uint8_t hw_ctrl_reg;
 #define DOR_REG 0x04
 #define ROR_REG 0x07
 #define READ_REG 0x08
-
-volatile __xdata __at 0x4020 uint8_t TS9347_R0;
-volatile __xdata __at 0x4021 uint8_t TS9347_R1;
-volatile __xdata __at 0x4022 uint8_t TS9347_R2;
-volatile __xdata __at 0x4023 uint8_t TS9347_R3;
-volatile __xdata __at 0x4024 uint8_t TS9347_R4;
-volatile __xdata __at 0x4025 uint8_t TS9347_R5;
-volatile __xdata __at 0x4026 uint8_t TS9347_R6;
-volatile __xdata __at 0x4027 uint8_t TS9347_R7;
-volatile __xdata __at 0x4028 uint8_t TS9347_ER0;
-volatile __xdata __at 0x4029 uint8_t TS9347_ER1;
-volatile __xdata __at 0x402A uint8_t TS9347_ER2;
-volatile __xdata __at 0x402B uint8_t TS9347_ER3;
-volatile __xdata __at 0x402C uint8_t TS9347_ER4;
-volatile __xdata __at 0x402D uint8_t TS9347_ER5;
-volatile __xdata __at 0x402E uint8_t TS9347_ER6;
-volatile __xdata __at 0x402F uint8_t TS9347_ER7;
-
-///////////////////////////////////////////////////////////
-// Modem
-///////////////////////////////////////////////////////////
-
-#define RXD_MODEM P3_3   // Modem -> CPU
-#define RTS_MODEM P1_4   // CPU -> Modem
-#define TXD_MODEM P1_3   // CPU -> Modem
-#define PRD_MODEM P1_2   // CPU -> Modem
-#define DCD_MODEM P1_1   // Modem -> CPU
-#define ZCO_MODEM P3_2   // Modem -> CPU
-
-// Note ENP set to high -> the register input is connected to PRD.
-
-#define RPROG 0x0
-#define RDTMF 0x1
-#define RATTE 0x2
-#define RWLO  0x3
-#define RPTF  0x4
-#define RHDL  0x5
-#define RPRX  0x6
-#define RPROGB  0x7


### PR DESCRIPTION
Hi! Would you be interested in targeting the Minitel 1B (NFZ 330) too in your demo program? Specifically, the one you [documented here](http://hxc2001.free.fr/yaquoidedans/Minitel-RTIC-Minitel9-NFZ330/index.html). I've also also been working on trying to emulate it in MAME, and I think you demo would be useful as a testcase for the EF9345 code paths :)

It turns out there are not a lot of differences from the Minitel 2 that the demo program should care about:

- The Minitel 1B has an EF9345 video chip instead of the TS9347. They are very similar (but not identical, as you know very well). This patch renames all the functions and names containing "ts9347" in their name to make them generic.

- Video chip registers TGS and PAT have to be initialized with different values.

- The modem of the Minitel 1B is of a different type (TS7513 instead of TS7514). This patch disables all the code paths involving the modem when compiled for the Minitel 1B.

- The Minitel 1B has a 11.0592 MHz crystal (instead of 14.318181 MHz). Therefore, the reload values of timers have to be adjusted accordingly to match the duration of timed delays.

Video proof that it works: :smile: 

https://github.com/user-attachments/assets/6ec978a2-69b2-40ae-8b99-91665b8f1096

Note: I saw that there's code that plays music through the modem in your demo, which I've disabled for the Minitel 1B. This Minitel only has a simple single-note (around 2675 Hz) buzzer, that we could try to use, if we want.

Note 2: You'll see that French special characters appear corrupted in the video. I think it's an encoding problem with my installation of SDCC, because I also see them like this in MAME with the Minitel 2 if I recompile the demo from source. Similarly, the 3D computations "explode" after a few iterations, I think for similar issues with my local compiler. 

If you're curious, here is a preliminary analysis of the board you showed [here](http://hxc2001.free.fr/yaquoidedans/Minitel-RTIC-Minitel9-NFZ330/minitel9-nfz330-rtic-motherboard-top.jpg):

![schematic](https://github.com/user-attachments/assets/1702e3fd-0b64-46ba-8615-4d8c1c3f4c89)

It's interesting that, unlike yours, in this particular Minitel there was no external ROM and the CPU was a P8052AH. But all the connections seem to match the board you've shown (except for the position of the resistor close to the EA pin, which selects booting from the internal or external ROM). Luckily, being a resistor, it's not hard to force EA in the opposite direction and make it boot externally anyway :)